### PR TITLE
Expose data property on RpcError

### DIFF
--- a/src/rpc-error.ts
+++ b/src/rpc-error.ts
@@ -10,4 +10,9 @@ export class RpcError<TError = any> extends Error {
   public getCode(): RpcErrorCode | number {
       return this.err.code;
   }
+
+  public getData(): TError | undefined {
+      return this.err.data;
+  }
+
 }

--- a/tests/rpc-client.spec.ts
+++ b/tests/rpc-client.spec.ts
@@ -2,6 +2,7 @@ import * as RpcServer from 'http-jsonrpc-server';
 import { RpcClientOptions } from '../src/interfaces';
 import { RpcClient } from '../src/rpc-client';
 import { RpcError } from '../src/rpc-error';
+import { RpcResponseError } from '../src/interfaces';
 import { RpcErrorCode } from '../src/rpc-error-codes.enum';
 
 describe('RpcClient', () => {
@@ -36,7 +37,7 @@ describe('RpcClient', () => {
         sumNamedParams,
         sumWithReturnType,
         invalidParms,
-        serverError,
+        serverError
       },
     });
     await rpcServer.listen(9090, 'localhost');
@@ -140,6 +141,19 @@ describe('RpcClient', () => {
       expect(error.getCode()).toEqual(RpcErrorCode.SERVER_ERROR);
     }
   });
+
+    // For this particular test we can't use the RpcServer instance because
+    // it doesn't expose a way to provoke an rpcError with data. 
+  it('should expose a data property on RpcError', async () => {
+    const data = {test: "test"}
+    const rpcError: RpcResponseError = {
+      code: RpcErrorCode.SERVER_ERROR,
+      message: 'Server Error',
+      data: data
+    }
+    const error = new RpcError(rpcError)
+    expect(error.getData()).toEqual(data);
+  });  
 
   it('should make batch requests', async () => {
     const { data } = await rpcClient.makeBatchRequest([


### PR DESCRIPTION
see #24 

**About the added jest test**: I'm not sure it is necessary, remove if not (this was my first test). The test couldn't use the `http-jsonrpc-server` as that package doesn't produce errors _with_  a `data` field (I've checked). However, I also tested the change against my own, live server which does.